### PR TITLE
Adding random number to end of API URL to prevent caching

### DIFF
--- a/src/uptimerobot.php
+++ b/src/uptimerobot.php
@@ -86,11 +86,11 @@ class UptimeRobot
 
         if (preg_match("#\?#", $url))
         {
-            $url .= '&apiKey=' . $this->getApiKey();
+            $url .= '&apiKey=' . $this->getApiKey() . "&rand=" . mt_rand(1000000, 10000000);
         }
         else
         {
-            $url .= '?apiKey=' . $this->getApiKey();
+            $url .= '?apiKey=' . $this->getApiKey() . "&rand=" . mt_rand(1000000, 10000000);
         }
 
         $url .= '&format=' . $this->format;


### PR DESCRIPTION
When using this library in my application, I found that multiple requests to the Uptime Robot API in the span of a few minutes were returning the same results, even if things had changed and were being reported differently in the dashboard (even when just attempting to make API requests directly from the browser). Adding a random number to the end of the API URL prevents this caching.